### PR TITLE
Adding `roaring.dll`, `roaring.so` to NuGet package as runtime dependencies

### DIFF
--- a/CRoaring.Net.targets
+++ b/CRoaring.Net.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <VersionPrefix>0.2.271</VersionPrefix>
+        <VersionPrefix>0.2.272</VersionPrefix>
         <IsTagBuild>true</IsTagBuild>
         <BuildNumber>1</BuildNumber>
         <VersionSuffix></VersionSuffix>

--- a/CRoaring.Net.targets
+++ b/CRoaring.Net.targets
@@ -1,13 +1,15 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <VersionPrefix>0.2.27</VersionPrefix>
+        <IsTagBuild>true</IsTagBuild>
+        <BuildNumber>1</BuildNumber>
         <VersionSuffix></VersionSuffix>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <PackageTags>croaring;roaring;bitmap</PackageTags>
-        <PackageProjectUrl>https://github.com/RogueException/CRoaring.Net</PackageProjectUrl>
+        <PackageProjectUrl>https://github.com/andersstorhaug/CRoaring.Net</PackageProjectUrl>
         <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
         <RepositoryType>git</RepositoryType>
-        <RepositoryUrl>git://github.com/RogueException/CRoaring.Net</RepositoryUrl>
+        <RepositoryUrl>git://github.com/andersstorhaug/CRoaring.Net</RepositoryUrl>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(BuildNumber)' == '' ">
         <VersionSuffix Condition=" '$(VersionSuffix)' != ''">$(VersionSuffix)-dev</VersionSuffix>

--- a/CRoaring.Net.targets
+++ b/CRoaring.Net.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <VersionPrefix>0.2.27</VersionPrefix>
+        <VersionPrefix>0.2.271</VersionPrefix>
         <IsTagBuild>true</IsTagBuild>
         <BuildNumber>1</BuildNumber>
         <VersionSuffix></VersionSuffix>

--- a/src/CRoaring.Net/CRoaring.Net.csproj
+++ b/src/CRoaring.Net/CRoaring.Net.csproj
@@ -9,10 +9,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Content Include="*.dll">
+      <Pack>true</Pack>
       <PackagePath>runtimes/win-x64/native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="*.so">
+      <Pack>true</Pack>
       <PackagePath>runtimes/linux-x64/native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/CRoaring.Net/CRoaring.Net.csproj
+++ b/src/CRoaring.Net/CRoaring.Net.csproj
@@ -7,11 +7,13 @@
     <TargetFrameworks>net45;netstandard1.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="*.dll">
+    <Content Include="*.dll">
+      <PackagePath>runtimes/win-x64/native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="*.so">
+    </Content>
+    <Content Include="*.so">
+      <PackagePath>runtimes/linux-x64/native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    </Content>
   </ItemGroup>
 </Project>

--- a/src/CRoaring.Net/CRoaring.Net.csproj
+++ b/src/CRoaring.Net/CRoaring.Net.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../CRoaring.Net.targets" />
   <PropertyGroup>
-    <AssemblyName>CRoaring.Net</AssemblyName>
+    <AssemblyName>CRoaring.NetStandard</AssemblyName>
     <RootNamespace>CRoaring</RootNamespace>
-    <Description>.Net wrapper for CRoaring - a C implementation of Roaring Bitmaps</Description>
+    <Description>.Net (+standard) wrapper for CRoaring - a C implementation of Roaring Bitmaps</Description>
     <TargetFrameworks>net45;netstandard1.1</TargetFrameworks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="*.dll">


### PR DESCRIPTION
This will include `roaring.dll` in the NuGet package with the new `.csproj` format.